### PR TITLE
Revert "Use detailed error codes to handle puppet errors"

### DIFF
--- a/solar/solar/core/handlers/puppet.py
+++ b/solar/solar/core/handlers/puppet.py
@@ -9,7 +9,20 @@ import os
 from solar.core.log import log
 from solar.core.handlers.base import TempFileHandler
 from solar.core.provider import GitProvider
-from solar import errors
+
+
+# TODO:
+# puppet wont always return 0 on error, example:
+# http://unix.stackexchange.com/questions/165333/how-to-get-non-zero-exit-code-from-puppet-when-configuration-cannot-be-applied
+
+# in fuel there is special handler based on puppet summary, but i think we can also use --detailed-exitcode
+# https://docs.puppetlabs.com/references/3.6.2/man/agent.html
+# --detailed-exitcodes
+# Provide transaction information via exit codes. If this is enabled, an exit
+# code of '2' means there were changes, an exit code of '4' means there were
+# failures during the transaction, and an exit code of '6' means there were
+# both changes and failures.
+
 
 
 class ResourceSSHMixin(object):
@@ -148,19 +161,14 @@ class Puppet(ResourceSSHMixin, TempFileHandler):
 
         self._scp_command(resource, action_file, '/tmp/action.pp')
 
-        cmd = self._ssh_command(
+        self._ssh_command(
             resource,
-            'puppet', 'apply', '-vd', '/tmp/action.pp', '--detailed-exitcodes',
+            'puppet', 'apply', '-vd', '/tmp/action.pp',
             env={
                 'FACTER_resource_name': resource.name,
             },
             use_sudo=True
         )
-        # 0 - no changes, 2 - successfull changes
-        if cmd.return_code not in [0, 2]:
-            raise errors.SolarError(
-                'Puppet for %s failed with %d', resource.name, cmd.return_code)
-        return cmd
 
     def clone_manifests(self, resource):
         git = resource.args['git'].value


### PR DESCRIPTION
Reverts Mirantis/solar#35

It causes error:

`Fatal error: sudo() received nonzero return code 2 while executing!`
