### PR TITLE
Uids history for solar cli commands

### DIFF
--- a/solar/solar/cli/orch.py
+++ b/solar/solar/cli/orch.py
@@ -7,6 +7,7 @@ import networkx as nx
 
 from solar.orchestration import graph
 from solar.orchestration import tasks
+from solar.cli.uids_history import SOLARUID
 
 
 @click.group(name='orch')
@@ -29,14 +30,14 @@ def create(plan):
 
 
 @orchestration.command()
-@click.argument('uid')
+@click.argument('uid', type=SOLARUID)
 @click.argument('plan', type=click.File('rb'))
 def update(uid, plan):
     graph.update_plan(uid, plan.read())
 
 
 @orchestration.command()
-@click.argument('uid')
+@click.argument('uid', type=SOLARUID)
 def report(uid):
     colors = {
         'PENDING': 'cyan',
@@ -53,7 +54,7 @@ def report(uid):
         click.echo(click.style(msg, fg=colors[item[1]]))
 
 @orchestration.command(name='run-once')
-@click.argument('uid')
+@click.argument('uid', type=SOLARUID)
 @click.option('--start', default=None)
 @click.option('--end', default=None)
 def run_once(uid, start, end):
@@ -63,20 +64,20 @@ def run_once(uid, start, end):
         queue='scheduler')
 
 @orchestration.command()
-@click.argument('uid')
+@click.argument('uid', type=SOLARUID)
 def restart(uid):
     graph.reset(uid)
     tasks.schedule_start.apply_async(args=[uid], queue='scheduler')
 
 
 @orchestration.command()
-@click.argument('uid')
+@click.argument('uid', type=SOLARUID)
 def reset(uid):
     graph.reset(uid)
 
 
 @orchestration.command()
-@click.argument('uid')
+@click.argument('uid', type=SOLARUID)
 def stop(uid):
     # TODO(dshulyak) how to do "hard" stop?
     # using revoke(terminate=True) will lead to inability to restart execution
@@ -86,21 +87,21 @@ def stop(uid):
 
 
 @orchestration.command()
-@click.argument('uid')
+@click.argument('uid', type=SOLARUID)
 def resume(uid):
     graph.reset(uid, ['SKIPPED'])
     tasks.schedule_start.apply_async(args=[uid], queue='scheduler')
 
 
 @orchestration.command()
-@click.argument('uid')
+@click.argument('uid', type=SOLARUID)
 def retry(uid):
     graph.reset(uid, ['ERROR'])
     tasks.schedule_start.apply_async(args=[uid], queue='scheduler')
 
 
 @orchestration.command()
-@click.argument('uid')
+@click.argument('uid', type=SOLARUID)
 def dg(uid):
     plan = graph.get_graph(uid)
 
@@ -122,6 +123,6 @@ def dg(uid):
 
 
 @orchestration.command()
-@click.argument('uid')
+@click.argument('uid', type=SOLARUID)
 def show(uid):
     click.echo(graph.show(uid))

--- a/solar/solar/cli/system_log.py
+++ b/solar/solar/cli/system_log.py
@@ -8,6 +8,7 @@ from solar.core import resource
 from solar.system_log import change
 from solar.system_log import operations
 from solar.system_log import data
+from solar.cli.uids_history import get_uid, remember_uid, SOLARUID
 
 
 @click.group()
@@ -35,11 +36,13 @@ def stage():
 
 @changes.command()
 def process():
-    click.echo(change.send_to_orchestration())
+    uid = change.send_to_orchestration()
+    remember_uid(uid)
+    click.echo(uid)
 
 
 @changes.command()
-@click.argument('uid')
+@click.argument('uid', type=SOLARUID)
 def commit(uid):
     operations.commit(uid)
 

--- a/solar/solar/cli/uids_history.py
+++ b/solar/solar/cli/uids_history.py
@@ -1,0 +1,58 @@
+import click
+import os
+import re
+
+UIDS_HISTORY = os.path.join(os.getcwd(), '.solar_cli_uids')
+
+
+def remember_uid(uid):
+    """
+    Remembers last 3 uids.
+    Can be used then as `last`, `last1`, `last2` anywhere
+    """
+    try:
+        with open(UIDS_HISTORY, 'rb') as f:
+            hist = [x.strip() for x in f.readlines()]
+    except IOError:
+        hist = []
+    hist.insert(0, uid)
+    if len(hist) > 3:
+        hist = hist[:3]
+    with open(UIDS_HISTORY, 'wb') as f:
+        f.write('\n'.join(hist))
+
+
+def get_uid(given_uid):
+    """
+    Converts given uid to real uid.
+    """
+    matched = re.search('last(\d*)', given_uid)
+    if matched:
+        try:
+            position = int(matched.group(1))
+        except ValueError:
+            position = 0
+        with open(UIDS_HISTORY, 'rb') as f:
+            uids = [x.strip() for x in f.readlines()]
+        try:
+            return uids[position]
+        except IndexError:
+            # fallback to original
+            return given_uid
+    return given_uid
+
+
+class SolarUIDParameterType(click.types.StringParamType):
+    """
+    Type for solar changes uid.
+    Works like a string but can convert `last(\d+)` to valid uid.
+    """
+    name = 'uid'
+
+    def convert(self, value, param, ctx):
+        value = click.types.StringParamType.convert(self, value, param, ctx)
+        value = get_uid(value)
+        return value
+
+
+SOLARUID = SolarUIDParameterType()


### PR DESCRIPTION
I implemented basic uids history (stored in `{cwd}/.solar_uids_history`).

It's very simple but works.
- everytime when you do `solar changes process` it stores the uid in file
- then you can use `last` `last0`, `last1`, `last2` as last 3 uids so you can use `solar orch dg last` etc.

I added it via `SOLARUID` type to click because I wanted to avoid mess.

Btw. It wasn't widely discussed before.
