### PR TITLE
DBObjectMeta should wrap functions only once

### DIFF
--- a/solar/solar/events/api.py
+++ b/solar/solar/events/api.py
@@ -21,8 +21,8 @@ from solar.core.log import log
 from solar.interfaces.db import get_db
 from solar.events.controls import Dep, React, StateChange
 
-db = get_db()
 
+db = get_db()
 
 
 def create_event(event_dict):
@@ -84,7 +84,7 @@ def add_events(resource, lst):
 
 def all_events(resource):
     events = db.get(resource, collection=db.COLLECTIONS.events,
-                    return_empty=True)
+                    db_convert=False, return_empty=True)
 
     if not events:
         return []

--- a/solar/solar/events/api.py
+++ b/solar/solar/events/api.py
@@ -84,7 +84,7 @@ def add_events(resource, lst):
 
 def all_events(resource):
     events = db.get(resource, collection=db.COLLECTIONS.events,
-                    db_convert=False, return_empty=True)
+                    return_empty=True)
 
     if not events:
         return []

--- a/solar/solar/interfaces/db/base.py
+++ b/solar/solar/interfaces/db/base.py
@@ -86,7 +86,10 @@ class DBObjectMeta(abc.ABCMeta):
                 func = from_db_list_decorator
             else:
                 func = from_db_decorator
-            dct[method_name] = func(node_db_to_object, method)
+            # Handle subclasses
+            if not getattr(method, '_wrapped', None):
+                dct[method_name] = func(node_db_to_object, method)
+                setattr(dct[method_name], '_wrapped', True)
 
         # Relation conversions
         for method_name, is_list in cls.relation_db_read_methods:
@@ -95,7 +98,10 @@ class DBObjectMeta(abc.ABCMeta):
                 func = from_db_list_decorator
             else:
                 func = from_db_decorator
-            dct[method_name] = func(relation_db_to_object, method)
+            # Handle subclasses
+            if not getattr(method, '_wrapped', None):
+                dct[method_name] = func(relation_db_to_object, method)
+                setattr(dct[method_name], '_wrapped', True)
 
         return super(DBObjectMeta, cls).__new__(cls, name, parents, dct)
 

--- a/solar/solar/interfaces/db/redis_graph_db.py
+++ b/solar/solar/interfaces/db/redis_graph_db.py
@@ -2,9 +2,6 @@ import json
 import redis
 import fakeredis
 
-from solar import utils
-from solar import errors
-
 from .base import BaseGraphDB, Node, Relation
 from .redis_db import OrderedHash
 


### PR DESCRIPTION
Before this patchset it could wrap multiple times in case of subclasses
(like for FakeRedisGraphDB).