### PR TITLE
Vagrant / Vbox system requirements adjustments

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,6 +38,7 @@ MASTER_IMAGE = cfg["master_image"]
 SYNC_TYPE = cfg["sync_type"]
 MASTER_CPUS = cfg["master_cpus"]
 SLAVES_CPUS = cfg["slaves_cpus"]
+PARAVIRT_PROVIDER = cfg.fetch('paravirtprovider', false)
 
 def ansible_playbook_command(filename, args=[])
   "ansible-playbook -v -i \"localhost,\" -c local /vagrant/bootstrap/playbooks/#{filename} #{args.join ' '}"
@@ -113,9 +114,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             "modifyvm", :id,
             "--memory", SLAVES_RAM,
             "--cpus", SLAVES_CPUS,
-            "--paravirtprovider", "kvm", # for linux guest
             "--ioapic", "on",
         ]
+        if PARAVIRT_PROVIDER
+          v.customize ['modifyvm', :id, "--paravirtprovider", PARAVIRT_PROVIDER] # for linux guest
+        end
         v.name = "solar-dev#{index}"
       end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+Vagrant.require_version ">= 1.7.0"
+
 require 'yaml'
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!

--- a/vagrant-settings.yaml_defaults
+++ b/vagrant-settings.yaml_defaults
@@ -8,6 +8,11 @@ slaves_image: cgenie/solar-master
 master_ram: 1024
 master_cpus: 1
 slaves_cpus: 1
+
+# if you have virtualbox 5.x then enable it
+# if will speedup things a lot
+# paravirtprovider: kvm
+
 # By default Virtualbox shared folder is used which is very slow
 # Uncomment following option to change it.
 # Possible options are: rsync, nfs


### PR DESCRIPTION
With this we can configure paravirt option from `vagrant-settings.yaml`.

On virtualbox 5.x we should set `paravirtprovider: kvm`