### PR TITLE
fixed dot generation for restricted names

### DIFF
--- a/solar/solar/core/signals.py
+++ b/solar/solar/core/signals.py
@@ -162,7 +162,7 @@ def detailed_connection_graph(start_with=None, end_with=None):
 
     def format_name(i):
         if isinstance(i, orm.DBResource):
-            return i.name
+            return '"{}"'.format(i.name)
         elif isinstance(i, orm.DBResourceInput):
             return '{}/{}'.format(i.resource.name, i.name)
 


### PR DESCRIPTION
before that when you had resource named `node` dot generation was not working. This fixes it.