### PR TITLE
Only one worker for system_log queue

### DIFF
--- a/bootstrap/playbooks/celery.yaml
+++ b/bootstrap/playbooks/celery.yaml
@@ -13,7 +13,7 @@
     - shell: celery multi stop 2  -A solar.orchestration.runner
              chdir={{ celery_dir }}
       tags: [stop]
-    - shell: celery multi start 2 -A solar.orchestration.runner -P:2 prefork -c:2 3 -Q:1 scheduler,system_log -Q:2 celery,{{ hostname.stdout }}
+    - shell: celery multi start 2 -A solar.orchestration.runner -P:2 prefork -c:1 1 -c:2 3 -Q:1 scheduler,system_log -Q:2 celery,{{ hostname.stdout }}
              chdir={{ celery_dir }}
       tags: [master]
     - shell: celery multi start 1 -A solar.orchestration.runner -Q:1  {{ hostname.stdout }}


### PR DESCRIPTION
If there are more than on worker for system_log queue it may lead to races when saving the graph