### PR TITLE
Packer builds for Juno image

### DIFF
--- a/bootstrap/playbooks/build-main.yaml
+++ b/bootstrap/playbooks/build-main.yaml
@@ -9,3 +9,4 @@
     - include: tasks/docker.yaml
     #- include: celery.yaml tags=['master'] celery_dir=/var/run/celery
     - include: tasks/cloud_archive.yaml
+    #- include: tasks/mos.yaml

--- a/bootstrap/playbooks/tasks/cloud_archive.yaml
+++ b/bootstrap/playbooks/tasks/cloud_archive.yaml
@@ -1,5 +1,7 @@
 ---
 
+- shell: apt-get update
+- shell: apt-get -y upgrade
 - shell: add-apt-repository -y cloud-archive:juno
 - shell: apt-get update
-- shell: apt-get -y dist-upgrade
+- shell: apt-get update --fix-missing

--- a/bootstrap/playbooks/tasks/mos.yaml
+++ b/bootstrap/playbooks/tasks/mos.yaml
@@ -1,0 +1,11 @@
+---
+
+- shell: apt-get update
+- shell: apt-get -y upgrade
+- apt_repository: repo='deb http://fuel-repository.mirantis.com/fwm/6.1/ubuntu mos6.1 main' validate_certs=no
+- shell: echo 'APT::Get::AllowUnauthenticated "true";' > /etc/apt/apt.conf.d/99mos61
+- shell: echo 'Package: *' > /etc/apt/preferences.d/mos.pref
+- shell: echo 'Pin: release o=Mirantis,a=mos6.1,n=mos6.1,l=mos6.1' >> /etc/apt/preferences.d/mos.pref
+- shell: echo 'Pin-Priority: 1050' >> /etc/apt/preferences.d/mos.pref
+- shell: apt-get update
+- shell: apt-get update --fix-missing


### PR DESCRIPTION
Provide packer build jobs for
Juno image with UCA (default) or MOS mirrors (disabled by default).

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>