### PR TITLE
Force mac address updates for slaves

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -151,6 +151,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             "--memory", SLAVES_RAM,
             "--cpus", SLAVES_CPUS,
             "--ioapic", "on",
+            "--macaddress1", "auto",
         ]
         if PARAVIRT_PROVIDER
           v.customize ['modifyvm', :id, "--paravirtprovider", PARAVIRT_PROVIDER] # for linux guest


### PR DESCRIPTION
When using VirtualBox as a provider, "slaves" had the same MAC as first network adapter in "master",
which was causing issues with networking. Now MAC will be randomly created.