### PR TITLE
Added riak storage_backend as input (also riak.conf is jinja processed)

### DIFF
--- a/resources/riak_node/meta.yaml
+++ b/resources/riak_node/meta.yaml
@@ -37,3 +37,6 @@ input:
     join_to:
       schema: str
       value:
+    storage_backend:
+      schema: str!
+      value: bitcask

--- a/resources/riak_node/templates/riak.conf.jinja
+++ b/resources/riak_node/templates/riak.conf.jinja
@@ -331,7 +331,7 @@ anti_entropy = active
 ## 
 ## Acceptable values:
 ##   - one of: bitcask, leveldb, memory, multi
-storage_backend = bitcask
+storage_backend = {{storage_backend}}
 
 ## Controls which binary representation of a riak value is stored
 ## on disk.


### PR DESCRIPTION
It allows to set riak storage backend (leveldb for example).