### PR TITLE
Unpin PyYAML version in requirements

### DIFF
--- a/solar/requirements.txt
+++ b/solar/requirements.txt
@@ -3,7 +3,7 @@ ply
 click==4.0
 jinja2==2.7.3
 networkx>=1.10
-PyYAML==3.11
+PyYAML>=3.1.0
 jsonschema==2.4.0
 requests==2.7.0
 dictdiffer==0.4.0


### PR DESCRIPTION
Pinning version of packages causes conflicts. Let's avoid that.
Since we need to work in OpenStack ecosystem, global requirements
was used as a reference.