### PR TITLE
Added index cache, fetching inputs values is faster

### DIFF
--- a/solar/solar/dblayer/solar_models.py
+++ b/solar/solar/dblayer/solar_models.py
@@ -245,8 +245,6 @@ class InputsFieldWrp(IndexFieldWrp):
         my_name = self._instance.key
         self._has_own_input(name)
         ind_name = '{}_recv_bin'.format(fname)
-        # XXX: possible optimization
-        # get all values for resource and cache it (use dirty to check)
         with self.inputs_index_cache as c:
             kwargs = dict(startkey='{}|'.format(my_name),
                           endkey='{}|~'.format(my_name),
@@ -257,17 +255,9 @@ class InputsFieldWrp(IndexFieldWrp):
             else:
                 max_results = 99999
             c.get_index(self._instance._get_index, ind_name, **kwargs)
-            # recvs = self._instance._get_index(ind_name,
-            #                                   **kwargs).results
             recvs = tuple(c.filter(startkey="{}|{}|".format(my_name, name),
                                    endkey="{}|{}|~".format(my_name, name),
                                    max_results=max_results))
-            # kwargs['max_results'] = max_results
-            # kwargs['startkey'] = "{}|{}|".format(my_name, name)
-            # kwargs['endkey'] = "{}|{}|~".format(my_name, name)
-            # recvs2 = self._instance._get_index(ind_name,
-            #                                   **kwargs).results
-            # assert recvs == recvs2
         if not recvs:
             _res = self._get_raw_field_val(name)
             self._cache[name] = _res


### PR DESCRIPTION
The idea is simple, instead fetching indexes values for each input separately, fist request fetches all, then other requests can use cached value.