### PR TITLE
Change the action about the vagrant defaults

### DIFF
--- a/vagrant-settings.yaml_defaults
+++ b/vagrant-settings.yaml_defaults
@@ -1,4 +1,4 @@
-# rename it to vagrant-settings.yaml then Vagrantfile
+# copy it to vagrant-settings.yaml then Vagrantfile
 # will use values from this file
 
 slaves_count: 2


### PR DESCRIPTION
The vagrant script checks for the presence of the defaults file before it moves to the custom one so we should copy it instead of move